### PR TITLE
feat: add intelligent HEVC video support with browser-based transcoding

### DIFF
--- a/src/mimetype_detector.rs
+++ b/src/mimetype_detector.rs
@@ -76,6 +76,7 @@ impl MimeType {
         &self.type_
     }
 
+    #[allow(dead_code)]
     pub fn subtype(&self) -> &str {
         &self.subtype
     }


### PR DESCRIPTION
## Summary

Adds intelligent HEVC (H.265) video playback support with automatic browser capability detection and conditional transcoding. This fixes playback issues with HEVC-encoded videos (e.g., modern smartphone videos from Pixel/iPhone) while optimizing performance for browsers with native HEVC support.

### Key Features

**Smart Browser Detection:**
- Uses Media Capabilities API to accurately detect HEVC support
- Fallback to `canPlayType()` for older browsers
- Safari/Edge users get original HEVC files (zero overhead)
- Chrome/Firefox users get transcoded H.264 files (seamless playback)

**Server-Side Processing:**
- HEVC detection using ffprobe
- On-demand H.264 transcoding with libopenh264 encoder
- Transcoded videos cached to `/tmp/turbo-pix/transcoded` (configurable via `TRANSCODE_CACHE_DIR`)
- Only transcodes when client explicitly requests via `?transcode=true` parameter

**Improved Metadata Extraction:**
- Uses ffprobe for accurate video codec detection
- Extracts real codec names instead of guessing from file extension
- Properly detects width, height, duration, bitrate, and frame rate

### Implementation Details

**Modified Files:**
- `src/video_processor.rs` - Added `is_hevc_video()`, `transcode_hevc_to_h264()`, `get_transcoded_path()`
- `src/handlers_video.rs` - Added conditional transcoding based on `?transcode=true` query parameter
- `src/metadata_extractor.rs` - Enhanced to use ffprobe for accurate codec detection
- `src/mimetype_detector.rs` - Fixed dead_code warning for `subtype()` method
- `static/js/viewer.js` - Added HEVC detection before loading videos

### System Requirements

**For Full Functionality:**
The default Fedora FFmpeg package lacks HEVC decoder support. To enable transcoding:

```bash
sudo dnf swap ffmpeg-free ffmpeg --allowerasing
```

**Without HEVC Decoder:**
- Safari/Edge users: No impact (native HEVC support)
- Chrome/Firefox users: Videos won't play (transcoding fails)

### Performance Characteristics

| Browser | Codec Support | Behavior | Overhead |
|---------|---------------|----------|----------|
| Safari/Edge | Native HEVC | Original file served | None |
| Chrome/Firefox | No HEVC | Transcoded H.264 served | First-time only |
| All (cached) | Any | Cached version served | Minimal |

### Test Plan

- [x] Code formatted with `cargo fmt` and `npm run format`
- [x] No clippy warnings (`cargo clippy`)
- [x] JavaScript linted (`npm run lint`)
- [ ] Test HEVC video playback in Safari (should serve original)
- [ ] Test HEVC video playback in Chrome (should transcode)
- [ ] Verify transcoded files are cached properly
- [ ] Test with full FFmpeg from RPM Fusion

### Future Improvements

- Automatic cache cleanup based on disk space/age
- Progress indication during transcoding
- Support for other codecs (VP9, AV1)
- Configurable quality/bitrate settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)